### PR TITLE
fix(CI): using more stable sized zip file for the upload large test

### DIFF
--- a/.github/workflows/benchmark-prs.yml
+++ b/.github/workflows/benchmark-prs.yml
@@ -113,11 +113,11 @@ jobs:
           summary-always: true
 
 
-      # The generated large single file (around 450MB) may vary little bit along the releases
+      # The generated large single file (around 300MB) may vary little bit along the releases
       - name: zip up release
         shell: bash
         run: |
-          tar -czvf release_zip.tar.gz ./target/release
+          tar -czvf release_zip.tar.gz ./target/release/deps
           ls -la
 
       # Start a heaptracked client instance to compare memory usage
@@ -244,8 +244,8 @@ jobs:
         id: client-memory-usage-check
         shell: bash
         env:
-          CLIENT_PEAK_MEM_LIMIT_MB: "1000" # mb
-          CLIENT_AVG_MEM_LIMIT_MB: "700" # mb
+          CLIENT_PEAK_MEM_LIMIT_MB: "1024" # ~1GB (unit is megabytes)
+          CLIENT_AVG_MEM_LIMIT_MB: "600" # mb
         run: |
           peak_mem_usage=$(rg "peak heap memory consumption" ./heaptrack.safe.txt | awk '{print $5}' | rg "M" -r "")
           echo "Peak memory usage: $peak_mem_usage MB"

--- a/.github/workflows/generate-benchmark-charts.yml
+++ b/.github/workflows/generate-benchmark-charts.yml
@@ -114,11 +114,11 @@ jobs:
           max-items-in-chart: 300
 
       # Start a heaptracked client instance to compare memory usage
-      # The generated large single file (around 450MB) may vary little bit along the releases
+      # The generated large single file (around 300MB) may vary little bit along the releases
       - name: Start client with heaptrack
         shell: bash
         run: |
-          tar -czvf release_zip.tar.gz ./target/release
+          tar -czvf release_zip.tar.gz ./target/release/deps
           heaptrack ./target/release/safe files upload ./release_zip.tar.gz
         env:
           SN_LOG: "all"
@@ -268,12 +268,12 @@ jobs:
           # Write the client memory usage to a file
           echo '[
               {
-                  "name": "Peak memory usage w/ ~450mb upload",
+                  "name": "Peak memory usage w/ ~300mb upload",
                   "value": '$peak_mem_usage',
                   "unit": "MB"
               },
               {
-                  "name": "Average memory usage w/ ~450mb upload",
+                  "name": "Average memory usage w/ ~300mb upload",
                   "value": '$average_mem',
                   "unit": "MB"
               }


### PR DESCRIPTION
The ./target/release/deps` folder is more stable regarding the file number and size.
Following is a comparation:
```
              File numbers     Total Size       zip file size
main             1218               1.3G              283MB
0.52            1212               1.299G             280MB  
```